### PR TITLE
React-Native: Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 *~
 node_modules
+.babelrc
+


### PR DESCRIPTION
Hi!

Thanks for this great module! I wanted to ask you whether you would be open to merge this pull request to fix builds for react native.

React-native applications currently also transpile third party modules that live under node_modules, which means that the presence of `.babelrc` affects the the transpilation process. To prevent this, the `.babelrc` file should be removed from the packaged npm module.